### PR TITLE
Added version constraint on yum cookbook to fix rhel/centos issues

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,4 @@
 site :opscode
 
 cookbook "omnibus"
+cookbook "yum", "< 3.0"

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -3,29 +3,29 @@
     "omnibus": {
       "locked_version": "1.0.8"
     },
+    "yum": {
+      "locked_version": "2.3.4"
+    },
     "apt": {
       "locked_version": "1.9.2"
     },
     "build-essential": {
-      "locked_version": "1.4.0"
+      "locked_version": "1.4.2"
     },
     "git": {
       "locked_version": "2.3.0"
     },
     "dmg": {
-      "locked_version": "1.1.0"
-    },
-    "yum": {
-      "locked_version": "2.3.0"
+      "locked_version": "2.0.8"
     },
     "windows": {
-      "locked_version": "1.10.0"
+      "locked_version": "1.8.10"
     },
     "chef_handler": {
       "locked_version": "1.1.4"
     },
     "runit": {
-      "locked_version": "1.1.6"
+      "locked_version": "1.1.4"
     },
     "homebrew": {
       "locked_version": "1.3.2"
@@ -40,7 +40,7 @@
       "locked_version": "1.1.0"
     },
     "7-zip": {
-      "locked_version": "1.0.0"
+      "locked_version": "1.0.2"
     }
   }
 }


### PR DESCRIPTION
Looks like the release of the 3.0 yum cookbook is what broke this for me.  The omnibus cookbook tries to include it and then has a rescue that hides the actual error message:

```
[2013-12-17T06:02:03+00:00] ERROR: could not find recipe epel for cookbook yum
Compiling Cookbooks...

================================================================================
Recipe Compile Error
================================================================================


Chef::Exceptions::RecipeNotFound
--------------------------------
could not find recipe epel for cookbook yum
```

If I remove the local changes to the Berksfile.lock - and manage to get Vagrant to run without modifying it, it works.  Otherwise it updates it to include 3.0 of yum and it breaks.  
