### PR TITLE
Vagrant won't 'up' with these 2 options set

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -62,8 +62,6 @@ Vagrant.configure("2") do |config|
   # The path to the Berksfile to use with Vagrant Berkshelf
   config.berkshelf.berksfile_path = "./Berksfile"
 
-  config.ssh.max_tries = 40
-  config.ssh.timeout   = 120
   config.ssh.forward_agent = true
 
   host_project_path = File.expand_path("..", __FILE__)


### PR DESCRIPTION
removed 2 ssh tweaks so 'vagrant up centos-6' runs:

sample-python-omnibus-app:$ vagrant up centos-6
Bringing machine 'centos-6' up with 'virtualbox' provider...
There are errors in the configuration of this machine. Please fix
the following errors and try again:

SSH:
- The following settings shouldn't exist: max_tries, timeout
