### PR TITLE
Bump to omnibus-1.3.0, latest omnibus-software

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'omnibus', '~> 1.2.0'
+gem 'omnibus', '~> 1.3.0'
 gem 'omnibus-software', :git => 'git://github.com/opscode/omnibus-software.git', :branch => 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: d8af8ab2a777ab1f08812b7c24afa87d5a795103
+  revision: 5ee2eae4a159f3c20dccf89e64a3532eadba2eff
   branch: master
   specs:
     omnibus-software (0.0.1)
@@ -11,59 +11,60 @@ GEM
     addressable (2.3.5)
     arr-pm (0.0.8)
       cabin (> 0)
-    backports (3.3.3)
+    backports (3.4.1)
     cabin (0.6.1)
-    childprocess (0.3.9)
+    childprocess (0.4.0)
       ffi (~> 1.0, >= 1.0.11)
-    clamp (0.6.1)
-    ffi (1.9.0)
-    fpm (0.4.42)
+    clamp (0.6.3)
+    ffi (1.9.3)
+    fpm (1.0.2)
       arr-pm (~> 0.0.8)
       backports (>= 2.6.2)
       cabin (>= 0.6.0)
       childprocess
       clamp (~> 0.6)
+      ffi
       ftw (~> 0.0.30)
       json (>= 1.7.7)
-    ftw (0.0.34)
+    ftw (0.0.39)
       addressable
       backports (>= 2.6.2)
       cabin (> 0)
       http_parser.rb (= 0.5.3)
     http_parser.rb (0.5.3)
     ipaddress (0.8.0)
-    json (1.8.0)
-    mime-types (1.25)
-    mixlib-cli (1.3.0)
-    mixlib-config (1.1.2)
+    json (1.8.1)
+    mime-types (1.25.1)
+    mixlib-cli (1.4.0)
+    mixlib-config (2.1.0)
     mixlib-log (1.6.0)
-    mixlib-shellout (1.2.0)
-    ohai (6.18.0)
+    mixlib-shellout (1.3.0)
+    ohai (6.20.0)
       ipaddress
       mixlib-cli
       mixlib-config
       mixlib-log
       mixlib-shellout
-      systemu
+      systemu (~> 2.5.2)
       yajl-ruby
-    omnibus (1.2.0)
-      fpm (~> 0.4.33)
-      mixlib-config (~> 1.1.2)
-      mixlib-shellout (~> 1.0)
+    omnibus (1.3.0)
+      fpm (~> 1.0.0)
+      mixlib-config (~> 2.1.0)
+      mixlib-shellout (~> 1.3.0)
       ohai (>= 0.6.12)
       rake (>= 0.9)
       thor (>= 0.16.0)
       uber-s3
-    rake (10.1.0)
+    rake (10.1.1)
     systemu (2.5.2)
     thor (0.18.1)
     uber-s3 (0.2.4)
       mime-types (~> 1.17)
-    yajl-ruby (1.1.0)
+    yajl-ruby (1.2.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  omnibus (~> 1.2.0)
+  omnibus (~> 1.3.0)
   omnibus-software!


### PR DESCRIPTION
Builds currently fail because the checksum for cacerts is
out-of-date. So bump to the latest omnibus-software commit on master
to fix this. Also bump to omnibus-1.3.0 and update Gemfile.lock with
new dependency versions.
